### PR TITLE
Added undeclared fields (php 8.2)

### DIFF
--- a/src/SxGeo.php
+++ b/src/SxGeo.php
@@ -47,6 +47,13 @@ class SxGeo
     protected $db;
     protected $regions_db;
     protected $cities_db;
+    protected $b_idx_len;
+    protected $id_len;
+    protected $max_region;
+    protected $max_city;
+    protected $block_len;
+    protected $max_country;
+    protected $pack;
 
     /**
      * SypexGeo database version.


### PR DESCRIPTION
PHP 8.2 send wornings:

```
LOG.warning: Creation of dynamic property Eseath\SxGeo\SxGeo::$b_idx_len is deprecated in 
/vendor/eseath/sypexgeo/src/SxGeo.php on line 98.

Previously undeclared fields have been added.
```
